### PR TITLE
add flat option

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,14 @@ const assert = require('assert')
 const flat = require('flat')
 const set = require('lodash.set')
 
-module.exports = function shakeTree (tree, targetKeys) {
+module.exports = function shakeTree (tree, targetKeys, opts = {}) {
   const list = flat(tree)
-  const keys = Object.keys(list)
+  let keys = Object.keys(list)
   const output = {}
+  const defaults = {
+    flat: false
+  }
+  opts = Object.assign(defaults, opts)
 
   assert.equal(typeof tree, 'object', 'argument `tree` must be an object')
   assert(targetKeys && targetKeys.length, 'argument `targetKeys` must be a key name or array of key names')
@@ -14,16 +18,24 @@ module.exports = function shakeTree (tree, targetKeys) {
     targetKeys = [targetKeys]
   }
 
-  keys
+  keys = keys
     .filter(key => {
       return list[key] &&
         list[key].length > 0 &&
         targetKeys.some(targetKey => key.split('.').pop() === targetKey)
     })
-    .forEach(key => {
+
+  if (opts.flat) {
+    const flatObj = {}
+    keys.forEach(key => {
+      flatObj[key] = list[key]
+    })
+    return flatObj
+  } else {
+    keys.forEach(key => {
       set(output, key, list[key])
     })
-
-  // Go to Stringtown and back to avoid upsetting some YAML formatters
-  return JSON.parse(JSON.stringify(output))
+    // Go to Stringtown and back to avoid upsetting some YAML formatters
+    return JSON.parse(JSON.stringify(output))
+  }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "electron-api-docs": "^1.6.8",
     "mocha": "^3.4.1",
     "standard": "^10.0.2",
-    "standard-markdown": "^2.3.0"
+    "standard-markdown": "^4.0.1"
   },
   "scripts": {
     "test": "mocha && standard && standard-markdown"

--- a/readme.md
+++ b/readme.md
@@ -24,10 +24,10 @@ that looks a bit like this:
   slug: 'browser-window',
   websiteUrl: 'http://electron.atom.io/docs/api/browser-window',
   repoUrl: 'https://github.com/electron/electron/blob/v1.4.0/docs/api/browser-window.md',
-  staticMethods: [...],
-  instanceMethods: [...],
-  instanceProperties: [...],
-  instanceEvents: [...]
+  staticMethods: ['...'],
+  instanceMethods: ['...'],
+  instanceProperties: ['...'],
+  instanceEvents: ['...']
 }
 ```
 
@@ -80,6 +80,41 @@ console.log(output)
 // You can also specify multiple keys to match:
 shakeTree(input, ['description', 'title'])
 ```
+
+## Flattening
+
+In some cases you might want the result as flat key-value object with 
+period-delimited strings as keys. In this case, set the `flat` option to `true`:
+
+This is useful if you want to preserve array indexes in the shaken tree.
+
+```js
+const input = {
+  a: [
+    {description: 'first a'},
+    {description: 'second a'}
+  ]
+}
+
+const output = shakeTree(input, 'description', {flat: true})
+
+console.log(output)
+// {
+//   'a.0.description': 'first a',
+//   'a.1.description': 'second a'
+// }
+```
+
+## API
+
+This module exports a single function.
+
+### `shakeTree(tree, targetKeys[, options])
+
+- `tree` - Object (required)
+- `targetKeys` - String or Array of Strings (required)
+- `options` - Object (optional)
+  - `flat` - Boolean (defaults to `false`)
 
 ## Tests
 

--- a/test/index.js
+++ b/test/index.js
@@ -73,4 +73,17 @@ describe('shakeTree', () => {
       expect(flatKeys.every(key => key.endsWith('.description')))
     })
   })
+
+  describe('options', () => {
+    let shaken
+
+    before(() => {
+      shaken = shakeTree(electronTree, 'description', {flat: true})
+    })
+
+    it('accepts a `flat` boolean that returns a key-value object with deep keys', () => {
+      const keys = Object.keys(shaken)
+      expect(keys).to.include('app.methods.getLoginItemSettings.returns.properties.0.properties.0.description')
+    })
+  })
 })


### PR DESCRIPTION
I realized that Electron API description YML files are losing their array index. Example: https://github.com/electron/electron-i18n/blob/a3256e88cacf589a82427c25ea274801740ffce1/content/en/api/api-descriptions.yml#L3574-L3583

This option will enable a more foolproof mapping that won't get lost in the JSON/YAML wash.